### PR TITLE
Makes it work in production.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -126,3 +126,22 @@ QUnit.test("Gets the top-level module", function(){
 	QUnit.deepEqual(loader.getBundles("tests/basics/d"), ["tests/basics/main"],
 				"main is the bundle");
 });
+
+QUnit.module("production", {
+	setup: function(assert){
+		makeLoader.call(this);
+
+		this.loader.baseURL = "./tests/production";
+		this.loader.bundles = {"bundles/main":["main"]};
+		this.loader.loadBundles = true;
+
+		var done = assert.async();
+		this.loader.import("main").then(function(){
+			done();
+		}, assertFailure("Failed to load"));
+	}
+});
+
+QUnit.test("Loads normally", function(){
+	QUnit.ok(true, "it loaded!");
+});

--- a/test/tests/production/dist/bundles/main.js
+++ b/test/tests/production/dist/bundles/main.js
@@ -1,0 +1,6 @@
+"format amd";
+define("main", [], function(){
+	return {
+		name: "main"
+	};
+});

--- a/trace.js
+++ b/trace.js
@@ -61,6 +61,11 @@ function applyTraceExtension(loader){
 	var limport = loader.import;
 	loader.import = function(){
 		var loader = this;
+
+		if(this.loadBundles) {
+			return limport.apply(this, arguments);
+		}
+
 		var amTracing = !!loader.trace;
 		loader.trace = true;
 		return limport.apply(this, arguments).then(function(r){
@@ -121,7 +126,8 @@ function applyTraceExtension(loader){
 	loader.instantiate = function(load){
 		this._traceData.loads[load.name] = load;
 		var loader = this;
-		return instantiate.apply(this, arguments).then(function(result){
+		var instantiatePromise = Promise.resolve(instantiate.apply(this, arguments));
+		return instantiatePromise.then(function(result){
 			if(loader.preventModuleExecution && !isEsLoad(load)) {
 				return {
 					deps: result && result.deps,


### PR DESCRIPTION
In production we need to disable the trace, otherwise it will try to
load the config.