### PR TITLE
getDependencies: return undefined when a module is not in the graph

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -48,11 +48,11 @@ QUnit.test("Gets the dependencies of a module", function(){
 
 });
 
-QUnit.test("Returns false when a module is not in the graph", function(){
+QUnit.test("Returns undefined when a module is not in the graph", function(){
 	var loader = this.loader;
 
-	QUnit.equal(loader.getDependencies("test/basics/not_in_graph"), false,
-				"false is returned when the module is not in the graph");
+	QUnit.equal(loader.getDependencies("test/basics/not_in_graph"), undefined,
+				"undefined is returned when the module is not in the graph");
 });
 
 QUnit.module("getDependants", {

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,13 @@ QUnit.test("Gets the dependencies of a module", function(){
 
 });
 
+QUnit.test("Returns false when a module is not in the graph", function(){
+	var loader = this.loader;
+
+	QUnit.equal(loader.getDependencies("test/basics/not_in_graph"), false,
+				"false is returned when the module is not in the graph");
+});
+
 QUnit.module("getDependants", {
 	setup: setupBasics
 });

--- a/trace.js
+++ b/trace.js
@@ -10,7 +10,7 @@ function applyTraceExtension(loader){
 
 	loader.getDependencies = function(moduleName){
 		var load = this.getModuleLoad(moduleName);
-		return load ? load.metadata.dependencies : false;
+		return load ? load.metadata.dependencies : undefined;
 	};
 	loader.getDependants = function(moduleName){
 		var deps = [];

--- a/trace.js
+++ b/trace.js
@@ -9,7 +9,8 @@ function applyTraceExtension(loader){
 	};
 
 	loader.getDependencies = function(moduleName){
-		return this.getModuleLoad(moduleName).metadata.dependencies;
+		var load = this.getModuleLoad(moduleName);
+		return load ? load.metadata.dependencies : false;
 	};
 	loader.getDependants = function(moduleName){
 		var deps = [];


### PR DESCRIPTION
Fixes #8 