### PR TITLE
Don't use transpiler to get dependencies

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -42,7 +42,8 @@ QUnit.test("Gets the dependencies of a module", function(){
 					"Correctly gets the dependencies for the main");
 
 	QUnit.deepEqual(loader.getDependencies("tests/basics/c"),
-					["tests/basics/d", "tests/basics/f"],
+					["tests/basics/d", "tests/basics/f",
+					"tests/basics/h"],
 					"Correctly gets the dependencies for the c module");
 
 
@@ -108,6 +109,10 @@ QUnit.test("Prevents a module from executing", function(){
 	var dDeps = loader.getDependencies("tests/basics/prevent_me").sort();
 	QUnit.deepEqual(dDeps, ["tests/basics/main", "tests/basics/prevent_es"],
 					"got the correct dependencies");
+
+	var cDeps = loader.getDependencies("tests/basics/c").sort();
+	QUnit.deepEqual(cDeps, ["tests/basics/d", "tests/basics/f",
+		"tests/basics/h"]);
 });
 
 QUnit.module("preventModuleExecution with babel", {

--- a/test/tests/basics/c.js
+++ b/test/tests/basics/c.js
@@ -1,4 +1,6 @@
 import './d';
-import './f';
+import {default as foo} from "./f";
+import foof from './h';
+
 
 export default function(){}

--- a/test/tests/basics/h.js
+++ b/test/tests/basics/h.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/trace.js
+++ b/trace.js
@@ -90,8 +90,22 @@ function applyTraceExtension(loader){
 		return res;
 	};
 
-	var transpiledDepsExp = /System\.register\((\[.+?\])\,/;
-	var singleQuoteExp = /'/g;
+	function regexAll(exp, str){
+		var results = [];
+		var res = exp.exec(str);
+
+		while(res) {
+			results.push(res);
+
+			res = exp.exec(str);
+		}
+
+		exp.lastIndex = 0;
+
+		return results;
+	}
+
+	var esDepsExp = /import .*["'](.+)["']/g;
 	var instantiate = loader.instantiate;
 	loader.instantiate = function(load){
 		this._traceData.loads[load.name] = load;
@@ -127,16 +141,12 @@ function applyTraceExtension(loader){
 		return instantiatePromise.then(function(result){
 			// This must be es6
 			if(!result) {
-				return loader.transpile(load).then(function(source){
-					load.metadata.transpiledSource = source;
-
-					var depsMatches = transpiledDepsExp.exec(source);
-					var depsSource = depsMatches ? depsMatches[1] : "[]";
-					var deps = JSON.parse(depsSource.replace(singleQuoteExp, '"'));
-					load.metadata.deps = deps;
-
-					return finalizeResult(result);
-				});
+				var res = regexAll(esDepsExp, load.source);
+				var deps = [];
+				for(var i = 0, len = res.length; i < len; i++) {
+					deps.push(res[i][1]);
+				}
+				load.metadata.deps = deps;
 			}
 			return finalizeResult(result);
 		});


### PR DESCRIPTION
This removes the user of a transpiler to get ES6 dependencies and
instead uses a regular expression.

Fixes #14 