### PR TITLE
Make es module tracer support export from

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/stealjs/system-trace",
   "devDependencies": {
-    "steal": "^0.11.0",
+    "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "testee": "^0.2.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -43,10 +43,16 @@ QUnit.test("Gets the dependencies of a module", function(){
 
 	QUnit.deepEqual(loader.getDependencies("tests/basics/c"),
 					["tests/basics/d", "tests/basics/f",
-					"tests/basics/h"],
+					"tests/basics/g"],
 					"Correctly gets the dependencies for the c module");
 
+	QUnit.deepEqual(loader.getDependencies("tests/basics/g"),
+					["tests/basics/h"],
+					"Correctly gets the dependencies for the g module");
 
+	QUnit.deepEqual(loader.getDependencies("tests/basics/h"),
+					["tests/basics/j"],
+					"Correctly gets the dependencies for the h module");
 });
 
 QUnit.test("Returns undefined when a module is not in the graph", function(){
@@ -112,7 +118,7 @@ QUnit.test("Prevents a module from executing", function(){
 
 	var cDeps = loader.getDependencies("tests/basics/c").sort();
 	QUnit.deepEqual(cDeps, ["tests/basics/d", "tests/basics/f",
-		"tests/basics/h"]);
+		"tests/basics/g"]);
 });
 
 QUnit.module("preventModuleExecution with babel", {

--- a/test/tests/basics/c.js
+++ b/test/tests/basics/c.js
@@ -4,7 +4,7 @@ import hello from './world';
 
 import './d';
 import {default as foo} from "./f";
-import foof from './h';
+import foof from './g';
 // import bar from './fake';
 
 

--- a/test/tests/basics/g.js
+++ b/test/tests/basics/g.js
@@ -1,0 +1,1 @@
+export * from "./h";

--- a/test/tests/basics/h.js
+++ b/test/tests/basics/h.js
@@ -1,1 +1,1 @@
-module.exports = {};
+export { foo } from './j';

--- a/test/tests/basics/j.js
+++ b/test/tests/basics/j.js
@@ -1,0 +1,1 @@
+export default function(){}

--- a/trace.js
+++ b/trace.js
@@ -90,12 +90,14 @@ function applyTraceExtension(loader){
 		return res;
 	};
 
-	var esDepsExp = /import .*["'](.+)["']/g;
+	var esImportDepsExp = /import .*["'](.+)["']/g;
+	var esExportDepsExp = /export .+["'](.+)["']/g;
 	var commentRegEx = /(^|[^\\])(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
 	var stringRegEx = /("[^"\\\n\r]*(\\.[^"\\\n\r]*)*"|'[^'\\\n\r]*(\\.[^'\\\n\r]*)*')/g;
 
 	function getESDeps(source) {
-		esDepsExp.lastIndex = commentRegEx.lastIndex = stringRegEx.lastIndex = 0;
+		esImportDepsExp.lastIndex = commentRegEx.lastIndex =
+			esExportDepsExp.lastIndex = stringRegEx.lastIndex = 0;
 
 		var deps = [];
 
@@ -111,6 +113,16 @@ function applyTraceExtension(loader){
 		  return false;
 		}
 
+		function addDeps(exp) {
+			while (match = exp.exec(source)) {
+			  // ensure we're not within a string or comment location
+			  if (!inLocation(stringLocations, match) && !inLocation(commentLocations, match)) {
+				var dep = match[1];//.substr(1, match[1].length - 2);
+				deps.push(dep);
+			  }
+			}
+		}
+
 		if (source.length / source.split('\n').length < 200) {
 		  while (match = stringRegEx.exec(source))
 			stringLocations.push([match.index, match.index + match[0].length]);
@@ -122,13 +134,8 @@ function applyTraceExtension(loader){
 		  }
 		}
 
-		while (match = esDepsExp.exec(source)) {
-		  // ensure we're not within a string or comment location
-		  if (!inLocation(stringLocations, match) && !inLocation(commentLocations, match)) {
-			var dep = match[1];//.substr(1, match[1].length - 2);
-			deps.push(dep);
-		  }
-		}
+		addDeps(esImportDepsExp);
+		addDeps(esExportDepsExp);
 
 		return deps;
 	}


### PR DESCRIPTION
This makes the es module tracer support the export from form of
declaring module dependencies in ES6:

```js
export * from 'bar';
```

```js
export { foo } from 'bar';
```