### PR TITLE
Fix trace detection with commented out import statements

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,37 @@ QUnit.test("Returns undefined when a module is not in the graph", function(){
 				"undefined is returned when the module is not in the graph");
 });
 
+QUnit.test("gets dependency below a commented out import #23", function(assert) {
+	var loader = this.loader;
+	var done = assert.async();
+
+	loader["import"]("tests/basics/k")
+		.then(function() {
+			assert.deepEqual(
+				loader.getDependencies("tests/basics/k"),
+				["tests/basics/b", "tests/basics/c", "tests/basics/d"],
+				"should not ignore dependencies below a commented out import"
+			);
+		})
+		.then(done);
+});
+
+
+QUnit.test("gets dependencies when there are comments between them #21", function(assert) {
+	var loader = this.loader;
+	var done = assert.async();
+
+	loader["import"]("tests/basics/l")
+		.then(function() {
+			assert.deepEqual(
+				loader.getDependencies("tests/basics/l"),
+				["tests/basics/h", "tests/basics/j"],
+				"should not ignore dependencies with comments between them"
+			);
+		})
+		.then(done);
+});
+
 QUnit.module("getDependants", {
 	setup: setupBasics
 });

--- a/test/tests/basics/k.js
+++ b/test/tests/basics/k.js
@@ -1,0 +1,4 @@
+// import something
+import b from './b';
+import c from './c';
+import d from './d';

--- a/test/tests/basics/l.js
+++ b/test/tests/basics/l.js
@@ -1,0 +1,3 @@
+import h from './h';
+/* this is a comment */
+import j from './j';

--- a/trace.js
+++ b/trace.js
@@ -92,19 +92,18 @@ function applyTraceExtension(loader){
 
 	var esImportDepsExp = /import [\s\S]*?["'](.+)["']/g;
 	var esExportDepsExp = /export .+ from ["'](.+)["']/g;
-	var commentRegEx = /(^|[^\\])(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg;
+	var commentRegEx = /(?:(?:^|\s)\/\/(.+?)$)|(?:\/\*([\S\s]*?)\*\/)/gm;
 	var stringRegEx = /(?:("|')[^\1\\\n\r]*(?:\\.[^\1\\\n\r]*)*\1|`[^`]*`)/g;
 
 	function getESDeps(source) {
+		var cleanSource = source.replace(commentRegEx, "");
+
 		esImportDepsExp.lastIndex = commentRegEx.lastIndex =
 			esExportDepsExp.lastIndex = stringRegEx.lastIndex = 0;
 
-		var deps = [];
-
 		var match;
-
-		// track string and comment locations for unminified source
-		var stringLocations = [], commentLocations = [];
+		var deps = [];
+		var stringLocations = []; // track string for unminified source
 
 		function inLocation(locations, match) {
 		  for (var i = 0; i < locations.length; i++)
@@ -114,24 +113,18 @@ function applyTraceExtension(loader){
 		}
 
 		function addDeps(exp) {
-			while (match = exp.exec(source)) {
-			  // ensure we're not within a string or comment location
-			  if (!inLocation(stringLocations, match) && !inLocation(commentLocations, match)) {
-				var dep = match[1];//.substr(1, match[1].length - 2);
+			while (match = exp.exec(cleanSource)) {
+			  // ensure we're not within a string location
+			  if (!inLocation(stringLocations, match)) {
+				var dep = match[1];
 				deps.push(dep);
 			  }
 			}
 		}
 
 		if (source.length / source.split('\n').length < 200) {
-		  while (match = stringRegEx.exec(source))
+		  while (match = stringRegEx.exec(cleanSource))
 			stringLocations.push([match.index, match.index + match[0].length]);
-
-		  while (match = commentRegEx.exec(source)) {
-			// only track comments not starting in strings
-			if (!inLocation(stringLocations, match))
-			  commentLocations.push([match.index, match.index + match[0].length]);
-		  }
 		}
 
 		addDeps(esImportDepsExp);


### PR DESCRIPTION
Closes #21 and #23

@Alfredo-Delgado I took the RegEx from https://github.com/sindresorhus/comment-regex, it's using  capturing groups that we don't need, should we remove them?

@matthewp I couldn't get the test for #21 to fail, can you take a look, am I missing anything? 
